### PR TITLE
POC for cog-llama 13B

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
-from transformers import LlamaTokenizer
+from transformers import AutoTokenizer
 
 DEFAULT_MODEL_NAME = "weights/llama-7b" # path from which we pull weights when there's no COG_WEIGHTS environment variable
 TOKENIZER_NAME = "weights/tokenizer"
@@ -10,11 +10,19 @@ DEFAULT_BOS_TOKEN = "</s>"
 DEFAULT_UNK_TOKEN = "</s>"
 
 
-def load_tokenizer():
+def load_tokenizer(model_name: str, model_max_length: int= 1024):
     """Same tokenizer, agnostic from tensorized weights/etc"""
-    tok = LlamaTokenizer.from_pretrained(
-        TOKENIZER_NAME, cache_dir="pretrained_weights"
-    )
+    #tok = LlamaTokenizer.from_pretrained(
+    #    TOKENIZER_NAME, cache_dir="pretrained_weights"
+    #)
+    
+    tokenizer = AutoTokenizer.from_pretrained(model_name,
+                                              model_max_length = model_max_length,
+                                              padding_side="right",
+                                              use_fast=False,
+                                            )
+    tok = tokenizer
+    
     tok.add_special_tokens(
     {
         "eos_token": DEFAULT_EOS_TOKEN,

--- a/scripts/train_multi_gpu_13B.sh
+++ b/scripts/train_multi_gpu_13B.sh
@@ -1,0 +1,25 @@
+PYTORCH_CUDA_ALLOC_CONF="max_split_size_mb:512" torchrun --nnodes=1 --nproc_per_node=4 --master_port=3333 \
+    training/trainer.py \
+    --model_name_or_path /llama/FastChat/weights \
+    --data_path /llama/cog-llama_1/examples/alpaca/short_alpaca_data_processed.json \
+    --bf16 True \
+    --output_dir ./checkpoints \
+    --num_train_epochs 3 \
+    --per_device_train_batch_size 1 \
+    --per_device_eval_batch_size 1 \
+    --gradient_accumulation_steps 4 \
+    --evaluation_strategy "no" \
+    --save_strategy "no" \
+    --save_steps 1200 \
+    --save_total_limit 100 \
+    --learning_rate 2e-5 \
+    --weight_decay 0. \
+    --warmup_ratio 0.03 \
+    --lr_scheduler_type "cosine" \
+    --logging_steps 1 \
+    --fsdp "full_shard auto_wrap" \
+    --fsdp_transformer_layer_cls_to_wrap 'LlamaDecoderLayer' \
+    --tf32 True \
+    --model_max_length 512 \
+    --gradient_checkpointing True \
+    --lazy_preprocess True

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -5,15 +5,16 @@ import os
 import time
 import logging
 from collections import OrderedDict
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from dataclasses import dataclass, field
 
 import torch
 from cog import Input, Path
 from peft import (LoraConfig, TaskType, get_peft_model,
                   prepare_model_for_int8_training)
 from torch.utils.data import Dataset
-from transformers import LlamaForCausalLM, Trainer, TrainingArguments, AutoConfig
-from tensorizer import TensorDeserializer
-from tensorizer.utils import no_init_or_tensor
+from transformers import LlamaForCausalLM, Trainer, TrainingArguments,AutoConfig, DataCollatorForSeq2Seq
+import transformers
 
 from config import DEFAULT_MODEL_NAME, load_tokenizer, CONFIG_LOCATION
 
@@ -23,6 +24,30 @@ SAVE_STRATEGY = "epoch"
 DIST_OUT_DIR = "tmp/model"
 IGNORE_INDEX = -100
 
+
+@dataclass
+class ModelArguments:
+    model_name_or_path: Optional[str] = field(default="facebook/opt-125m")
+
+
+@dataclass
+class DataArguments:
+    data_path: str = field(default=None,
+                           metadata={"help": "Path to the training data."})
+    lazy_preprocess: bool = False
+
+
+@dataclass
+class TrainingArguments(transformers.TrainingArguments):
+    cache_dir: Optional[str] = field(default=None)
+    optim: str = field(default="adamw_torch")
+    model_max_length: int = field(
+        default=512,
+        metadata={
+            "help":
+            "Maximum sequence length. Sequences will be right padded (and possibly truncated)."
+        },
+    )
 
 class DatasetBuilder:
     """Dataset agnostic class to take in input_ids and labels and spit out tokens"""
@@ -47,7 +72,6 @@ class DatasetBuilder:
         tokenized_labels = self.batch_tokenize(labels)
         return TuneDataset(tokenized_input_ids, tokenized_labels)
 
-
 class CausalDatasetBuilder(DatasetBuilder):
     """Builds generative dataset for Causal LM."""
 
@@ -70,8 +94,6 @@ class CausalDatasetBuilder(DatasetBuilder):
             label[:source_len] = IGNORE_INDEX
         return TuneDataset(input_ids, labels)
 
-
-
 class TuneDataset(Dataset):
     """Dead simple torch dataset wrapper. Attention masks are created in collator"""
 
@@ -86,7 +108,7 @@ class TuneDataset(Dataset):
         return dict(input_ids=self.input_ids[i], labels=self.labels[i])
 
 
-class SequenceDataCollator:
+class SequenceDataCollator():
     """Collate examples for dynamic batch construction in supervised fine-tuning."""
 
     def __init__(self, tokenizer, multiple_of=None):
@@ -134,7 +156,7 @@ class SequenceDataCollator:
         )
 
 
-def load_data(path):
+def load_data(path: Path) -> List[dict]:
     if path.suffix == ".json":
         return load_json(path)
     elif path.suffix == ".jsonl":
@@ -160,249 +182,38 @@ def load_json(path):
         data = json.load(f)
     return data
 
-
-def load_model(model_name_or_path):
-    if model_name_or_path is None:
-        model_name_or_path = DEFAULT_MODEL_NAME
-    st = time.time()
-    print(f"deserializing weights from {model_name_or_path}")
-    config = AutoConfig.from_pretrained(CONFIG_LOCATION)
-
-    model = no_init_or_tensor(
-        lambda: LlamaForCausalLM.from_pretrained(
-            None, config=config, state_dict=OrderedDict()
-        )
-    )
-    des = TensorDeserializer(model_name_or_path, plaid_mode=False)
-    des.load_into_module(model)
-    des.close()
-    print(f"weights loaded in {time.time() - st}")
-    return model
-
-
-def load_peft_model(
-    model_name_or_path, lora_rank: int, lora_alpha: int, lora_dropout: float
-):
-    if model_name_or_path is None:
-        model_name_or_path = DEFAULT_MODEL_NAME
-    model = LlamaForCausalLM.from_pretrained(
-        model_name_or_path,
-        cache_dir="pretrained_weights",
-        torch_dtype=torch.float16,
-        load_in_8bit=True,
-        device_map="auto",
-    )
-    model = prepare_model_for_int8_training(model)
-    config = LoraConfig(
-        r=lora_rank,
-        lora_alpha=lora_alpha,
-        lora_dropout=lora_dropout,
-        bias="none",
-        task_type=TaskType.SEQ_2_SEQ_LM,
-    )
-    model = get_peft_model(model, config)
-    return model
-
-
-def train(
-    train_data: Path = Input(
-        description="path to data file to use for fine-tuning your model"
-    ),
-    eval_data: Path = Input(
-        description="path to optional evaluation data file to use for model eval",
-        default=None,
-    ),
-    weights: Path = Input(
-        description="location of weights that are going to be fine-tuned", default=None
-    ),
-    train_batch_size: int = Input(description="batch size per GPU", default=8, ge=1),
-    gradient_accumulation_steps: int = Input(
-        description="number of training steps to update gradient for before performing a backward pass",
-        default=8,
-    ),
-    lr_scheduler_type: str = Input(
-        description="learning rate scheduler",
-        default="cosine",
-        choices=[
-            "linear",
-            "cosine",
-            "cosine_with_restarts",
-            "polynomial",
-            "inverse_sqrt",
-            "constant",
-            "constant_with_warmup",
-        ],
-    ),
-    learning_rate: float = Input(
-        description="learning rate, for learning!", default=2e-4, ge=0
-    ),
-    warmup_ratio: float = Input(
-        description="pct of steps for a linear learning rate warmup",
-        ge=0,
-        le=0.5,
-        default=0.03,
-    ),
-    num_train_epochs: int = Input(
-        description="number of training epochs", ge=1, default=1
-    ),
-    max_steps: int = Input(
-        description="number of steps to run training for, supersedes num_train_epochs",
-        default=-1,
-        ge=0,
-    ),
-    logging_steps: int = Input(
-        description="number of steps between logging epoch & loss", default=1
-    ),
-    local_output_dir: str = None,
-    deepspeed: str = None,
-    local_rank: int = -1,
-) -> None:
+        
+def train():
     print("Loading model...")
+    parser = transformers.HfArgumentParser(
+        (ModelArguments, DataArguments, TrainingArguments))
+    model_args, data_args, training_args = parser.parse_args_into_dataclasses()
+    model = transformers.LlamaForCausalLM.from_pretrained(
+        model_args.model_name_or_path,
+        cache_dir=training_args.cache_dir,
+    )
 
-    # if peft:
-    #     print("training lora!")
-    #     model = load_peft_model(weights, lora_rank, lora_alpha, lora_dropout)
-    model = load_model(weights)
-    tokenizer = load_tokenizer()
+    tokenizer = load_tokenizer(model_args.model_name_or_path, training_args.model_max_length)
 
-    print(f"Loading dataset {train_data}...")
-    print(train_data)
-    train_data = load_data(train_data)
+    print(f"Loading dataset {data_args.data_path}...")
+    print(data_args.data_path)
+    train_data = load_data(Path(data_args.data_path))
     p = CausalDatasetBuilder(tokenizer)
     train_dataset = p.construct_dataset(train_data)
-    eval_dataset = None
-    if eval_data:
-        eval_data = load_json(eval_data)
-        eval_dataset = p.construct_dataset(eval_data)
-    torch.cuda.empty_cache()
 
-    print("Training...")
-    trainer = Trainer(
-        model=model,
-        train_dataset=train_dataset,
-        eval_dataset=eval_dataset,
-        args=TrainingArguments(
-            output_dir=CHECKPOINT_DIR,
-            per_device_train_batch_size=train_batch_size,
-            gradient_accumulation_steps=gradient_accumulation_steps,
-            save_strategy="no",
-            logging_steps=logging_steps,
-            lr_scheduler_type=lr_scheduler_type,
-            warmup_ratio=warmup_ratio,
-            num_train_epochs=num_train_epochs,
-            learning_rate=learning_rate,
-            deepspeed=deepspeed,
-            max_steps=max_steps,
-            tf32=True,
-            bf16=True,
-            half_precision_backend="cuda_amp",
-            local_rank=local_rank,
-        ),
-        data_collator=SequenceDataCollator(tokenizer, 8),  # depends on bf16 value
-    )
+    data_collator =SequenceDataCollator(tokenizer, 8)
+    trainer = Trainer(model=model,
+                    tokenizer=tokenizer,
+                    args=training_args,
+                    train_dataset=train_dataset,
+                    eval_dataset=None,
+                    data_collator=data_collator)
+
+
     trainer.train()
-    trainer.save_model(output_dir=local_output_dir)
-    return
-
+    trainer.save_state()
+    trainer.save_model(output_dir=training_args.output_dir)
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Fine-tune a language model on a text dataset"
-    )
-    parser.add_argument(
-        "--train_data", type=Path, required=True, help="Path to the json dataset"
-    )
-    parser.add_argument(
-        "--eval_data",
-        type=Path,
-        required=False,
-        help="Path to the json dataset",
-        default=None,
-    )
-    parser.add_argument(
-        "--weights",
-        type=str,
-        default=None,
-        help="The model class to fine-tune on HF or as a local path (e.g. 'google/flan-t5-xxl'",
-    )
-    parser.add_argument(
-        "--num_train_epochs", type=int, required=True, help="Number of training epochs"
-    )
-    parser.add_argument(
-        "--learning_rate",
-        type=float,
-        default=2e-5,
-        help="Learning rate for the optimizer",
-    )
-    parser.add_argument(
-        "--train_batch_size", type=int, default=4, help="Batch size for training"
-    )
-    parser.add_argument(
-        "--warmup_ratio",
-        type=float,
-        default=0.03,
-        help="Number of warmup steps for the learning rate scheduler",
-    )
-    parser.add_argument(
-        "--max_steps",
-        type=int,
-        default=0,
-        help="Number of training steps to run, overrides num_train_epochs, useful for testing",
-    )
-    parser.add_argument(
-        "--gradient_accumulation_steps",
-        type=int,
-        default=8,
-        help="Number of training steps to run, overrides num_train_epochs, useful for testing",
-    )
-    parser.add_argument("--logging_steps", type=int, default=1)
-    parser.add_argument(
-        "--lr_scheduler_type",
-        type=str,
-        default="cosine",
-    )
-    parser.add_argument(
-        "--deepspeed", type=str, default=None, help="Path to deepspeed config file."
-    )
-    parser.add_argument(
-        "--local_output_dir",
-        type=str,
-        help="Write directly to this local path",
-        required=True,
-    )
-    parser.add_argument(
-        "--local_rank",
-        type=int,
-        default=-1,
-        help="Provided by deepspeed to identify which instance this process is when performing multi-GPU training.",
-    )
-    some_args = parser.parse_args()
-    train(**vars(some_args))
+    train()
 
-    # parser.add_argument(
-    #     "--local_rank",
-    #     type=int,
-    #     default=0
-    # )
-    # parser.add_argument(
-    #     "--peft",
-    #     action="store_true"
-    # )
-    # parser.add_argument(
-    #     "--lora_rank",
-    #     type=int,
-    #     default=16,
-    #     help="Number of training steps to run, overrides num_train_epochs, useful for testing",
-    # )
-    # parser.add_argument(
-    #     "--lora_alpha",
-    #     type=int,
-    #     default=16,
-    #     help="Number of training steps to run, overrides num_train_epochs, useful for testing",
-    # )
-    # parser.add_argument(
-    #     "--lora_dropout",
-    #     type=float,
-    #     default=0.4,
-    #     help="Number of training steps to run, overrides num_train_epochs, useful for testing",
-    # )


### PR DESCRIPTION
With the code uploaded plus this command, it is possible to train the 13B llama in a 4xA100 80GB

```
PYTORCH_CUDA_ALLOC_CONF="max_split_size_mb:512" torchrun --nnodes=1 --nproc_per_node=4 --master_port=3333 \
    training/trainer.py \
    --model_name_or_path /llama/FastChat/weights \
    --data_path /llama/cog-llama_1/examples/alpaca/short_alpaca_data_processed.json \
    --bf16 True \
    --output_dir ./checkpoints \
    --num_train_epochs 3 \
    --per_device_train_batch_size 1 \
    --per_device_eval_batch_size 1 \
    --gradient_accumulation_steps 4 \
    --evaluation_strategy "no" \
    --save_strategy "no" \
    --save_steps 1200 \
    --save_total_limit 100 \
    --learning_rate 2e-5 \
    --weight_decay 0. \
    --warmup_ratio 0.03 \
    --lr_scheduler_type "cosine" \
    --logging_steps 1 \
    --fsdp "full_shard auto_wrap" \
    --fsdp_transformer_layer_cls_to_wrap 'LlamaDecoderLayer' \
    --tf32 True \
    --model_max_length 512 \
    --gradient_checkpointing True \
    --lazy_preprocess True
```

    
    Optimizations applied:

PYTORCH_CUDA_ALLOC_CONF: This is an environment variable to configure CUDA memory allocation in PyTorch.
torchrun --nnodes=1 --nproc_per_node=4 --master_port=3333: This command starts a distributed PyTorch training job with 1 node, 4 processes per node, and a master port of 3333.
training/trainer.py: This is the main training script that will be executed.
--model_name_or_path /llama/FastChat/weights: Specifies the model weights to initialize the training from.
--data_path /llama/cog-llama_1/examples/alpaca/short_alpaca_data_processed.json: Specifies the path to the preprocessed training data file.
--bf16 True: Enables bfloat16 precision for training.
--output_dir ./checkpoints: Specifies the directory where the model checkpoints will be saved.
--num_train_epochs 3: Sets the number of training epochs to 3.
--per_device_train_batch_size 1: Sets the training batch size per device to 1.
--per_device_eval_batch_size 1: Sets the evaluation batch size per device to 1.
--gradient_accumulation_steps 4: Sets the number of gradient accumulation steps before an optimizer step.
--evaluation_strategy "no": Disables the evaluation strategy.
--save_strategy "steps": Sets the save strategy to save the model at specified steps.
--save_steps 1200: Sets the frequency of model saving, in this case, every 1200 steps.
--save_total_limit 100: Limits the total number of saved checkpoints to 100.
--learning_rate 2e-5: Sets the learning rate to 2e-5.
--weight_decay 0.: Sets the weight decay (L2 regularization) to 0.
--warmup_ratio 0.03: Sets the warmup ratio for the learning rate scheduler.
--lr_scheduler_type "cosine": Sets the learning rate scheduler type to "cosine".
--logging_steps 1: Sets the frequency of logging information, in this case, every 1 step.
--fsdp "full_shard auto_wrap": Configures the Fully Sharded Data Parallel (FSDP) training mode with the "full_shard auto_wrap" setting.
--fsdp_transformer_layer_cls_to_wrap 'LlamaDecoderLayer': Specifies the transformer layer class to wrap for FSDP.
--tf32 True: Enables TensorFloat-32 (TF32) precision for training.
--model_max_length 512: Sets the maximum sequence length for the model to 512 tokens.
--gradient_checkpointing True: Enables gradient checkpointing to save memory during training.
--lazy_preprocess True: Enables lazy preprocessing of the data, which can save memory and time during training.

**More possible optimisations:**

Increase --gradient_accumulation_steps: Experiment with higher values like 8 or 16

Maybe using: 
* garbage_collection_threshold here: PYTORCH_CUDA_ALLOC_CONF="max_split_size_mb:512,garbage_collection_threshold:0.8" 
      https://pytorch.org/docs/stable/notes/cuda.html#memory-management 